### PR TITLE
Setting the proper default load_address when not specified by the user

### DIFF
--- a/atosl.c
+++ b/atosl.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include <getopt.h>
 #include <libgen.h>
+#include <limits.h>
 
 #include <dwarf.h>
 #include <libdwarf.h>
@@ -97,7 +98,7 @@ static struct {
     cpu_subtype_t cpu_subtype;
     const char *cache_dir;
 } options = {
-    .load_address = 0x0,
+    .load_address = LONG_MAX,
     .use_globals = 0,
     .use_cache = 1,
     .cpu_subtype = CPU_SUBTYPE_ARM_V7S,
@@ -939,7 +940,6 @@ int main(int argc, char *argv[]) {
     Dwarf_Debug dbg = NULL;
     Dwarf_Error err;
     int derr = 0;
-    int enable_default_load_addr = 1;
     Dwarf_Obj_Access_Interface *binary_interface = NULL;
     Dwarf_Ptr errarg = NULL;
     int option_index;
@@ -959,7 +959,6 @@ int main(int argc, char *argv[]) {
                 if (address < 0)
                     fatal("unable to parse load address: `%s'", optarg);
                 options.load_address = address;
-                enable_default_load_addr = 0;
                 break;
             case 'o':
                 options.dsym_filename = optarg;
@@ -1070,7 +1069,7 @@ int main(int argc, char *argv[]) {
     dwarf_mach_object_access_init(fd, &binary_interface, &derr);
     assert(binary_interface);
 
-    if (enable_default_load_addr)
+    if (options.load_address == LONG_MAX)
         options.load_address = context.intended_addr;
 
     ret = dwarf_object_init(binary_interface,


### PR DESCRIPTION
'./atosl -o ./Facebook 0x000b764a' gives correct output - 'FBURLRequestHostForSubdomain (in Facebook) (_FBURLRequestGenerateURLRequest.mm:89)'
