### PR TITLE
Stabs support (function symbols only)

### DIFF
--- a/README.stabs
+++ b/README.stabs
@@ -1,0 +1,26 @@
+This file describes the sequence of stabs as produced by clang, as far as I've seen in test files.
+This is a tiny subset of the full stabs format, which is described in detail at:
+	https://sourceware.org/gdb/current/onlinedocs/stabs.html
+
+The sequence of stabs as produced by clang is:
+
+Per translation unit:
+  * An N_SO symbol with the source directory name (e.g. /Users/btv/MyApp/)
+  * An N_SO symbol with the source file basename (e.g. AppDelegate.m)
+  * An N_OSO symbol with the full path to the object file (e.g.
+    /Users/btv/MyApp/build/MyApp.build/Debug-iphoneos/MyApp.build/Objects-normal/armv7/AppDelegate.o )
+    Note that this can be a temp file with a useless name if intermediate object files weren't generated
+    during the build process.
+  * The functions defined in that translation unit, each with the following four symbols:
+    * N_BNSYM, whose value is the beginning address of the function
+    * N_FUN, whose string is the (possibly mangled) function name and whose value is the same as for N_BNSYM.
+    * (Note: Sometimes N_SOL can appear here, but it doesn't seem to have anything to do with the function.)
+    * N_FUN (again), whose string is blank and whose value is the length of the function.
+    * N_ENSYM, whose string is blank and whose value is (again) the length of the function.
+  * Some N_GSYM and N_STSYM symbols. These describe global and static variables, respectively.
+    Their value is the address of the symbol; and their string is a mangled version of their name
+    (e.g. OBJC_CLASS_$_DetailViewController)
+
+A word on N_SOL: It describes header files included in the current translation unit.
+The pattern to when and where it shows up is mysterious. Sometimes it precedes all the functions defined in
+the header file, but not always.

--- a/atosl.c
+++ b/atosl.c
@@ -489,7 +489,7 @@ static int compare_symbols(const void *a, const void *b)
     return sym_a->addr - sym_b->addr;
 }
 
-void do_print_symbol(const char *symbol, unsigned offset)
+void print_symbol(const char *symbol, unsigned offset)
 {
     char *demangled = options.should_demangle ? demangle(symbol) : NULL;
     const char *name = demangled ? demangled : symbol;
@@ -534,7 +534,7 @@ int handle_stabs_symbol(int is_fun_stab, Dwarf_Addr search_addr, const struct sy
                         symbol->addr, symbol->addr);
             if (last_addr <= search_addr
                     && search_addr < last_addr + symbol->addr) {
-                do_print_symbol(last_fun_name, (unsigned int)(search_addr - last_addr));
+                print_symbol(last_fun_name, (unsigned int)(search_addr - last_addr));
                 return 1;
             } else if (debug)
                 fprintf(stderr, "\t\tNot printing symbol %s; 0x%llx not in the interval [0x%llx 0x%llx).\n",
@@ -557,7 +557,7 @@ int handle_stabs_symbol(int is_fun_stab, Dwarf_Addr search_addr, const struct sy
     return 0;
 }
 
-int print_symtab_symbol(Dwarf_Addr slide, Dwarf_Addr addr)
+int find_and_print_symtab_symbol(Dwarf_Addr slide, Dwarf_Addr addr)
 {
     union {
         struct nlist_t nlist32;
@@ -632,7 +632,7 @@ int print_symtab_symbol(Dwarf_Addr slide, Dwarf_Addr addr)
             }
 
             struct symbol_t *prev = (current - 1);
-            do_print_symbol(prev->name, (unsigned int)(addr - prev->addr));
+            print_symbol(prev->name, (unsigned int)(addr - prev->addr));
             found = 1;
             break;
         }
@@ -1318,7 +1318,7 @@ int main(int argc, char *argv[]) {
             addr = strtol(argv[i], (char **)NULL, 16);
             if (errno != 0)
                 fatal("invalid address address: `%s': %s", optarg, strerror(errno));
-            ret = print_symtab_symbol(
+            ret = find_and_print_symtab_symbol(
                     options.load_address - context.intended_addr,
                     addr);
 

--- a/atosl.c
+++ b/atosl.c
@@ -562,6 +562,17 @@ int print_symtab_symbol(Dwarf_Addr slide, Dwarf_Addr addr)
             fprintf(stderr, "\t\taddr: 0x%llx\n", current->addr);
         }
 
+        /* Print function names based on stab information.
+         *
+         * See README.stabs for stabs format information.
+         *
+         * Here we find pairs of N_FUN stabs. The first has the name of the function and its starting address;
+         * the second has its size.
+         *
+         * We could also symbolicate global and static symbols (N_GSYM and N_STSYM) here,
+         * but it's not necessary to do so since they'll be picked up by the generic symbol table
+         * search later in this function.
+         */
         if (is_stab && type == N_FUN) {
             if (last_fun_name) {
                 if (debug)

--- a/atosl.h
+++ b/atosl.h
@@ -40,6 +40,8 @@
 #define N_PBUD 0xc
 #define N_INDR 0xa
 
+#define N_FUN 0x24
+
 #define CPU_TYPE_ARM ((cpu_type_t)12)
 #define CPU_SUBTYPE_ARM_V6 ((cpu_subtype_t)6)
 #define CPU_SUBTYPE_ARM_V7 ((cpu_subtype_t)9)


### PR DESCRIPTION
Read function symbols in STABS format.

Partially addresses #31  .

Unfortunately, all I could find in the STABS in executables created by clang were information on source files, addresses of functions, global variables, and static variables.

Notably absent are line numbers, so we can only know what function a code address is in, not what line of source code it corresponds to. I'd be very happy to be wrong about this, and would love to learn about some magical clang flag that causes more verbose stabs to be output.

If Zack thinks it's useful, I can follow up by parsing the N_SO symbols in order to print source file information. I haven't done it yet because we can't determine reliably whether something was defined in the primary source file of a translation unit or in a header file.

Test plan:
* Made a simple iOS app. Compiled it with -g -O0 using xcodebuild.
* Deleted all standalone debug information including the intermediate compile results and the .dSYM folder.
* Tested atosl and atos on several addresses and verified that both tools reported them as pointing to the same function.

