### PR TITLE
Put the usual stuff in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 atosl
-atosl.dep
-atosl.o
-common.dep
-common.o
-subprograms.dep
-subprograms.o
+*.o
+*.dep
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+atosl
+atosl.dep
+atosl.o
+common.dep
+common.o
+subprograms.dep
+subprograms.o
+tags


### PR DESCRIPTION
I don't know if we have a good reason for not having a .gitignore in this repo, but if not, feel free to merge this. It just includes everything created by `make`, plus the ctags file.
