### PR TITLE
Guard for redefinition of DW_LANG_Swift

### DIFF
--- a/subprograms.h
+++ b/subprograms.h
@@ -20,7 +20,10 @@
 #define SUBPROGRAMS_CACHE_MAGIC   0xcaceecac
 #define SUBPROGRAMS_CACHE_VERSION 1
 #define SUBPROGRAMS_CACHE_PATH    ".atosl-cache"
+
+#ifndef DW_LANG_Swift
 #define DW_LANG_Swift             0x1e
+#endif
 
 enum subprograms_type_t {
     SUBPROGRAMS_GLOBALS,


### PR DESCRIPTION
Newer version of libdwarf already include this define, so only define it
if it isn't already.